### PR TITLE
fix(footer): Force prettier to ignore the copyright line

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,9 +2,9 @@
   <div class="footer-content">
     <p class="footer-text">
       &copy;
-      {{ if site.Params.copyright.startYear }}
-        {{ site.Params.copyright.startYear }}-
-      {{ end }}{{ now.Year }}
+      {{/* prettier-ignore-start */}}
+      {{ if site.Params.copyright.startYear }}{{ site.Params.copyright.startYear }}-{{ end }}{{ now.Year }}
+      {{/* prettier-ignore-end */}}
       {{ site.Params.copyright.owner | default site.Title }}.
       {{ if site.Params.footerText }}
         {{ site.Params.footerText }}


### PR DESCRIPTION
Looks like the config for prettier causes the copyright notice in the footer to render differently due to it forcing components in the template onto new lines, which is interpreted as a space. This change forces it back onto a single line in the template, and wraps that line (and *only* that line) in an override for prettier to not process it. I left the other components of that part of the footer as their own lines (per the formatting) as they're space-separated anyways.

Effect: `2025- 2026` -> `2025-2026` (just the space after the `-`).