### PR TITLE
[Draft] Feature/sections show all child pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ Add this to your config:
   listSectionsRecursive = true # This is the line to add. Note that it defaults to false if you don't specify it.
 ```
 
-Also, given that managing sections can become quite tedious (creating an `_index.md` for every folder, and setting the title) we have included a [python script](./scripts/sections.py) to handle that for you. You can also get a bit more context about it in the associated [readme](./scripts/README.md).
+Note, however, that if you want this option to work properly, you need to convert *all* relevant paths in the target folder hierarhcy to sections. Given that managing sections can become quite tedious (creating an `_index.md` for every folder, and setting the title) we have included a [python script](./scripts/sections.py) to handle that for you. You can also get a bit more context about it in the associated [readme](./scripts/README.md).
 
 ## Post Frontmatter
 

--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ Add this to your config:
 
 ```toml
 [params] # You should already have this line, so just find that section.
-  listSectionsRecursive = true # This is the line to add.
+  listSectionsRecursive = true # This is the line to add. Note that it defaults to false if you don't specify it.
 ```
 
 Also, given that managing sections can become quite tedious (creating an `_index.md` for every folder, and setting the title) we have included a [python script](./scripts/sections.py) to handle that for you. You can also get a bit more context about it in the associated [readme](./scripts/README.md).

--- a/README.md
+++ b/README.md
@@ -425,6 +425,19 @@ To use Umami:
 
 The Umami script will be automatically included in your site's `<head>` section.
 
+### Sections & listSectionsRecursive
+
+If you want to use [sections](https://gohugo.io/content-management/sections/) (e.g. to allow you to list all posts in a given folder hierarchy) the theme supports optionally listing all posts recursively. This would mean that accessing `/posts/2026/` would show everything not only in `2026`, but also everything in `2026/01` and `2026/01/01` (if that's the sort of folder hierarchy you use).
+
+Add this to your config:
+
+```toml
+[params] # You should already have this line, so just find that section.
+  listSectionsRecursive = true # This is the line to add.
+```
+
+Also, given that managing sections can become quite tedious (creating an `_index.md` for every folder, and setting the title) we have included a [python script](./scripts/sections.py) to handle that for you. You can also get a bit more context about it in the associated [readme](./scripts/README.md).
+
 ## Post Frontmatter
 
 The theme supports standard Hugo frontmatter. For post images, add an `image` parameter:

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -40,7 +40,7 @@ allDates = "All Dates"
 clearFilters = "Clear Filters"
 
 # Pagination
-pageOf = "Page %s of %s"
+pageOf = "Page %d of %d"
 postSingular = "post"
 postPlural = "posts"
 pageSingular = "page"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -40,7 +40,7 @@ allDates = "Toutes les dates"
 clearFilters = "Effacer les filtres"
 
 # Pagination
-pageOf = "Page %s sur %s"
+pageOf = "Page %d sur %d"
 postSingular = "article"
 postPlural = "articles"
 pageSingular = "page"

--- a/i18n/he.toml
+++ b/i18n/he.toml
@@ -40,7 +40,7 @@ allDates = "כל התאריכים"
 clearFilters = "נקה מסננים"
 
 # Pagination
-pageOf = "עמוד %s מתוך %s"
+pageOf = "עמוד %d מתוך %d"
 postSingular = "פוסט"
 postPlural = "פוסטים"
 pageSingular = "עמוד"

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -40,7 +40,7 @@ allDates = "すべての日付"
 clearFilters = "フィルターをクリア"
 
 # ページネーション
-pageOf = "%sページ中 %sページ目"
+pageOf = "%dページ中 %dページ目"
 postSingular = "投稿"
 postPlural = "投稿"
 pageSingular = "ページ"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -16,6 +16,12 @@
   {{ end }}
   {{ $uniqueYearMonths := $yearMonths | uniq | sort }}
 
+  {{ $pages := cond (site.Params.listSectionsRecursive | default false)
+    .RegularPagesRecursive
+    .RegularPages
+  }}
+
+  {{ $paginator := .Paginate $pages }}
 
   <div class="list-container">
     <header class="list-header">
@@ -25,7 +31,7 @@
       {{ if .Description }}
         <p class="list-description">{{ .Description }}</p>
       {{ end }}
-      {{ partial "list-count.html" . }}
+      {{ partial "list-count.html" (dict "paginator" $paginator) }}
     </header>
 
     <!-- Filter Controls -->
@@ -97,7 +103,7 @@
     </div>
 
     <div class="posts-list" id="posts-container">
-      {{ range .Paginator.Pages }}
+      {{ range $paginator.Pages }}
         {{ $dataTags := "" }}
         {{ if .Params.tags }}
           {{ $dataTags = delimit .Params.tags "," }}

--- a/layouts/partials/list-count.html
+++ b/layouts/partials/list-count.html
@@ -1,8 +1,9 @@
-<div class="list-count">
-  <span id="filtered-count">{{ .Paginator.TotalNumberOfElements }}</span>
-  {{ if eq .Paginator.TotalNumberOfElements 1 }}{{ i18n "postSingular" }}{{ else }}{{ i18n "postPlural" }}{{ end }}
-  {{ if gt .Paginator.TotalPages 1 }}
-    <span class="list-count-pages">({{ .Paginator.TotalPages }} {{ if eq .Paginator.TotalPages 1 }}{{ i18n "pageSingular" }}{{ else }}{{ i18n "pagePlural" }}{{ end }})</span>
+{{/* The paginator is passed in from list.html, which is why it's lowercase. */}}
+ <div class="list-count">
+  <span id="filtered-count">{{ .paginator.TotalNumberOfElements }}</span>
+  {{ if eq .paginator.TotalNumberOfElements 1 }}{{ i18n "postSingular" }}{{ else }}{{ i18n "postPlural" }}{{ end }}
+  {{ if gt .paginator.TotalPages 1 }}
+    <span class="list-count-pages">({{ .paginator.TotalPages }} {{ if eq .paginator.TotalPages 1 }}{{ i18n "pageSingular" }}{{ else }}{{ i18n "pagePlural" }}{{ end }})</span>
   {{ end }}
 </div>
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,23 @@
+# Scripts
+
+Helper tools that aren't required for using the theme, but may help with some tasks. These things are optional, so don't worry if you don't know why someone would want these things.
+
+## Listing
+
+### Section Management
+
+For those wanting to take advantage of Hugo's [sections](https://gohugo.io/content-management/sections/) but not wanting to manage the `_index.md` files manually, this script handles it for you.
+
+Note that as with any tool that modifies your content in any way, you should enesure your files are backed up and/or tracked in a VCS (e.g. `git`).
+
+For those curious, a sample folder hierarchy that benefits from this could be `content/posts/1978/11/18/do-you-remember-the-21st-of-september.md`.
+
+#### Usage
+
+These commands assume you're in your site's base folder, with this repo saved in `themes/mana/`.
+
+To create default sections: `python3 themes/mana/scripts/sections.py generate content/posts`
+
+To clean up sections: `python3 themes/mana/scripts/sections.py cleanup content/posts`
+
+So what is each of these commands doing? The `generate` command will navigate the folder hierarchy under `content/posts` and add `_index.md` files to every folder, and attempt to auto-generate a title. Note that this script assumes there aren't any existing `_index.md` files, and so it will overwrite any that exist. The `cleanup` command does the reverse of `generate`: it'll navigate the specified folder hierarchy and delete any `_index.md` files it finds.

--- a/scripts/sections.py
+++ b/scripts/sections.py
@@ -1,0 +1,75 @@
+import os
+import sys
+from collections.abc import Callable
+
+
+def generate_title(path: str, root_dir: str) -> str:
+    trimmed = (
+        path
+        .removeprefix(root_dir)
+        .removeprefix('/')  # Account for the user not using a trailing slash.
+    )
+
+    return f'Posts for {trimmed}'
+
+
+def make_section(path: str, root_dir: str) -> None:
+    content = f'---\ntitle: {generate_title(path, root_dir)}\n---'
+    with open(f'{path}/_index.md', 'w') as f:
+        f.write(content)
+
+
+def remove_section(path: str, root_dir: str) -> None:
+    if os.path.isfile(f'{path}/_index.md'):
+        os.remove(f'{path}/_index.md')
+
+
+def walk_tree(root_dir: str, task: Callable[[str, str], None]) -> None:
+    for dir_path, dir_names, file_names in os.walk(root_dir):
+        if dir_path == root_dir:
+            continue
+
+        task(dir_path, root_dir)
+
+
+def print_usage() -> None:
+    print('Usage:')
+    print('python3 sections.py [command] [path]')
+    print()
+    print('[command] must be one of "generate" or "cleanup"')
+    print()
+    print('[path] must be the path to your content')
+    print()
+    print('Example: python3 sections.py generate content/posts')
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print_usage()
+        sys.exit(1)
+
+    command: Callable
+
+    # Ensure command is in [generate, cleanup]
+    if sys.argv[1] == 'generate':
+        command = make_section
+    elif sys.argv[1] == 'cleanup':
+        command = remove_section
+    else:
+        print(f'Unknown command: {sys.argv[1]}.')
+        print_usage()
+        sys.exit(1)
+
+    # Verify target_path exists and is a folder
+    target_path = sys.argv[2]
+    if not os.path.isdir(target_path):
+        print(f'Path ({target_path}) does not appear to be a directory.')
+        sys.exit(1)
+
+    walk_tree(target_path, command)
+
+
+# Only execute if explicitly invoked.
+# Prevents unexpected behaviour if someone imports this file.
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
For #55 (I finally made the time to sit down and deal with this).

Adding a new optional param `listSectionsRecursive` (`true`/`false`). If false or unset, it preserves the existing behaviour as far as I'm able to tell. If `true` (and all relevant folders are converted to sections by adding `_index.md` to each) then all the mid-level folders will show a list of all child/descendant pages, rather than a 404.

Note, however, that this requires all the folders under `/content/posts` to have `_index.md` (ideally with title set). I threw together this Taskfile to make my life easier:

```yaml
version: "3"

vars:
  THEME: mana
  POSTS_DIR: "./content/posts"
  POSTS_DIR_ESC: '.\/content\/posts\/'

tasks:
  server:
    deps:
      - clean
    cmds:
      - hugo server -t {{.THEME}}

  clean:
    cmds:
      - rm -rf ./public/

  debug:
    deps:
      - clean
    cmds:
      - hugo server -D -t {{.THEME}}

  prod:
    deps:
      - clean
    cmds:
      - hugo build -t {{.THEME}}

  sections.mk:
    cmds:
      - |
        find {{.POSTS_DIR}}/* -type d | sed 's/{{.POSTS_DIR_ESC}}//' | while read line; do printf "---\ntitle: Posts for $line\n---" > "{{.POSTS_DIR}}/$line/_index.md"; done

  sections.rm:
    cmds:
      - find {{.POSTS_DIR}}/* -type f -name _index.md -exec rm {} +
```

So every time I create a post, I'll just need to run `task sections.mk` and it'll set everything up for me. Note though that I use the structure `/content/posts/2026/02/28/making-time-for-tinkering.md` so it might need some adjustments if people are using another structure. If you don't put a title in the files, all page titles for the folders will just be `| My Cool Site` instead of `Posts | My Cool Site` or `Posts for 2026 | My Cool Site`.

Given these caveats, I'm not sure if this is still a feature you're open to. And if it is, I'm not sure how you'd want to call these things out to other users.