### PR TITLE
windows percent error

### DIFF
--- a/layouts/partials/post-image-resolve.html
+++ b/layouts/partials/post-image-resolve.html
@@ -35,18 +35,22 @@
     {{ $staticPath := printf "static/images/%s%s" $titleSlug . }}
     {{ $assetPath := printf "assets/images/%s%s" $titleSlug . }}
     
-    {{/* Check static folder first. Skip fileExists if path has % (Windows invalid) */}}
-    {{ if and (not (findRE "%" $staticPath)) (fileExists $staticPath) }}
-      {{ $image = $potentialImage }}
-      {{/* Files in static/ are served directly, no resource needed */}}
-      {{ break }}
+    {{/* Check static folder first. Skip fileExists if path has % (Windows invalid - and doesn't short-circuit) */}}
+    {{ if not (findRE "%" $staticPath) }}
+      {{ if fileExists $staticPath }}
+        {{ $image = $potentialImage }}
+        {{/* Files in static/ are served directly, no resource needed */}}
+        {{ break }}
+      {{ end }}
     {{ end }}
     
     {{/* Check assets folder (processed as resources). Skip fileExists if path has % (Windows invalid) */}}
-    {{ if and (not (findRE "%" $assetPath)) (fileExists $assetPath) }}
-      {{ $image = $potentialImage }}
-      {{ $imageResource = resources.Get (printf "images/%s%s" $titleSlug .) }}
-      {{ break }}
+    {{ if not (findRE "%" $assetPath) }}
+      {{ if fileExists $assetPath }}
+        {{ $image = $potentialImage }}
+        {{ $imageResource = resources.Get (printf "images/%s%s" $titleSlug .) }}
+        {{ break }}
+      {{ end }}
     {{ end }}
   {{ end }}
 


### PR DESCRIPTION
Hugo’s and function evaluates all arguments before returning, so fileExists was still called even when the path contained %. On Windows, paths with % can trigger filesystem errors.

Change: Replaced and with nested if blocks so fileExists is only called when the path does not contain %:

{{/* Before - fileExists was still evaluated when path had % */}}
{{ if and (not (findRE "%" $staticPath)) (fileExists $staticPath) }}
{{/* After - fileExists only runs when path is safe */}}
{{ if not (findRE "%" $staticPath) }}
  {{ if fileExists $staticPath }}
This pattern is applied for both the static/images/ and assets/images/ checks. When the title slug is URL-encoded (e.g. Hebrew), the path includes % and fileExists is skipped, avoiding the Windows error.